### PR TITLE
Refactor queryUtils tests

### DIFF
--- a/tests/shared/queryUtils.sampleQueries.test.ts
+++ b/tests/shared/queryUtils.sampleQueries.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeQueryText } from '../../utils/shared/queryUtils';
+
+describe('sample queries from logs', () => {
+  const cases: Array<[string, string]> = [
+    [
+      'how does this compare with 2024?',
+      'how does this compare with 2024?'
+    ],
+    [
+      'Query: how does this compare to 2024 data?\n\nAnalysis Summary: Incomparable data detected',
+      'how does this compare to 2024 data?'
+    ],
+    [
+      'Query: What factors related to job choice, staying with a company?\n\nAnalysis: LLM-driven file identification',
+      'What factors related to job choice, staying with a company?'
+    ],
+    [
+      'what is the level of trust employees have in their direct managers?',
+      'what is the level of trust employees have in their direct managers?'
+    ],
+    [
+      '\nQuery: What are the primary reasons employees may be resistant to returning to the office full-time?\n\nAnalysis Summary: LLM-driven file identification',
+      'What are the primary reasons employees may be resistant to returning to the office full-time?'
+    ],
+    [
+      '\n\nQuery: How does this compare to 2024?\n\nAnalysis Summary: Incomparable data detected for year-on-year comparison',
+      'How does this compare to 2024?'
+    ]
+  ];
+
+  cases.forEach(([input, expected]) => {
+    it(`normalizes \"${input.substring(0, 30).replace(/\n/g, ' ')}...\"`, () => {
+      expect(normalizeQueryText(input)).toBe(expected);
+    });
+  });
+});

--- a/utils/shared/queryUtils.ts
+++ b/utils/shared/queryUtils.ts
@@ -183,26 +183,3 @@ export function createThreadContext(
     isFollowUp,
   };
 }
-
-// For testing purposes - can be removed in production
-if (require.main === module) {
-  // Test with sample queries from logs
-  const queries = [
-    "how does this compare with 2024?",
-    "Query: how does this compare to 2024 data?\n\nAnalysis Summary: Incomparable data detected",
-    "Query: What factors related to job choice, staying with a company?\n\nAnalysis: LLM-driven file identification",
-    "what is the level of trust employees have in their direct managers?",
-    "\nQuery: What are the primary reasons employees may be resistant to returning to the office full-time?\n\nAnalysis Summary: LLM-driven file identification",
-    "\n\nQuery: How does this compare to 2024?\n\nAnalysis Summary: Incomparable data detected for year-on-year comparison"
-  ];
-  
-  // Log normalized results
-  queries.forEach(q => {
-    console.log(`Original: "${q.substring(0, 40)}..."`);
-    console.log(`Normalized: "${normalizeQueryText(q)}"\n`);
-  });
-  
-  // Run the test function if invoked directly with Node
-  console.log("Running tests for normalizeQueryText...");
-  console.log("All tests completed.");
-} 


### PR DESCRIPTION
## Summary
- strip inline test logic from `queryUtils.ts`
- port sample queries to a new `queryUtils.sampleQueries.test.ts`

## Testing
- `npm run test:unit` *(fails: vitest not found)*