### PR TITLE
Remove test-openai references

### DIFF
--- a/RIA25_Documentation/specification_v2/17_file_function_reference.md
+++ b/RIA25_Documentation/specification_v2/17_file_function_reference.md
@@ -59,10 +59,6 @@ This document provides a comprehensive mapping of all major files and functions 
   - `OPTIONS(request)`: Handles CORS preflight requests
   - `GET(request)`: Tests API key validity
 
-- `app/api/test-openai/route.ts`
-  - `OPTIONS(request)`: Handles CORS preflight requests
-  - `GET(request)`: Tests OpenAI API connectivity
-
 ### Controllers
 
 - `app/api/controllers/chatAssistantController.ts`

--- a/vercel.json
+++ b/vercel.json
@@ -74,10 +74,6 @@
             "memory": 1024,
             "maxDuration": 60
         },
-        "app/api/test-openai/route.ts": {
-            "memory": 1024,
-            "maxDuration": 30
-        },
         "app/api/test-assistant/route.ts": {
             "memory": 1024,
             "maxDuration": 30


### PR DESCRIPTION
## Summary
- remove `test-openai` function from `vercel.json`
- drop stale `test-openai` section from documentation

## Testing
- `npm test` *(fails: vitest not found)*