### PR TITLE
Fix script references in spec v2 docs

### DIFF
--- a/RIA25_Documentation/specification_v2/01_project_overview.md
+++ b/RIA25_Documentation/specification_v2/01_project_overview.md
@@ -50,7 +50,7 @@ RIA25 (Research Insights Assistant 2025) is an AI-powered system designed to pro
 
 The system comprises:
 
-- **Data Processing Pipeline**: Transforms raw CSV survey data into structured JSON with harmonization and canonical topic mapping (see `process_survey_data.ts`, `process_2025_data.ts`)
+- **Data Processing Pipeline**: Transforms raw CSV survey data into structured JSON with harmonization and canonical topic mapping (see `process_survey_data.js`, `process_2025_data.js`)
 - **Vector Store**: OpenAI vector database for efficient retrieval of relevant survey data
 - **Prompt System**: Engineered prompts guiding AI responses and enforcing data integrity
 - **API Layer**: Next.js API endpoints orchestrating query handling, data retrieval, validation, and logging

--- a/RIA25_Documentation/specification_v2/02_implementation_plan.md
+++ b/RIA25_Documentation/specification_v2/02_implementation_plan.md
@@ -18,10 +18,10 @@ This document outlines the implemented architecture, development workflow, and t
 
 ### 1. Data Processing Pipeline
 
-- **Implemented Solution**: TypeScript scripts to process CSV data into structured JSON
+- **Implemented Solution**: Node.js scripts (JavaScript) to process CSV data into structured JSON
 - **Key Scripts**:
-  - `process_survey_data.ts`: Transforms raw CSV data into structured JSON files
-  - `process_2025_data.ts`: Handles 2025-specific data harmonization
+  - `process_survey_data.js`: Transforms raw CSV data into structured JSON files
+  - `process_2025_data.js`: Handles 2025-specific data harmonization
 - **Output Format**: JSON files split by question number with consistent metadata structure
 - **Location**: `scripts/` directory
 

--- a/RIA25_Documentation/specification_v2/03_data_processing_workflow.md
+++ b/RIA25_Documentation/specification_v2/03_data_processing_workflow.md
@@ -35,8 +35,8 @@ Raw CSV Data → Data Validation → Column Mapping → JSON Transformation → 
 
 - **Purpose**: Ensure data integrity and harmonize structure across years before processing
 - **Implementation**:
-  - Initial data validation in `process_survey_data.ts`
-  - Advanced harmonization and validation in `process_2025_data.ts`
+  - Initial data validation in `process_survey_data.js`
+  - Advanced harmonization and validation in `process_2025_data.js`
   - Canonical topic mapping and normalization logic
 - **Checks**:
   - CSV format verification
@@ -48,7 +48,7 @@ Raw CSV Data → Data Validation → Column Mapping → JSON Transformation → 
 ### 3. Column Mapping
 
 - **Purpose**: Create flexible mapping between CSV columns and structured JSON
-- **Implementation**: Dynamic column mapping in `process_survey_data.ts` and harmonization in `process_2025_data.ts`
+- **Implementation**: Dynamic column mapping in `process_survey_data.js` and harmonization in `process_2025_data.js`
 - **Benefits**:
   - Resilience to column order changes
   - Adaptation to CSV format variations
@@ -57,7 +57,7 @@ Raw CSV Data → Data Validation → Column Mapping → JSON Transformation → 
 ### 4. JSON Transformation
 
 - **Purpose**: Convert raw CSV data into structured JSON
-- **Implementation**: Transformation logic in `process_survey_data.ts` and `process_2025_data.ts`
+- **Implementation**: Transformation logic in `process_survey_data.js` and `process_2025_data.js`
 - **Structure**:
   - Consistent metadata format
   - Demographic information categorization
@@ -68,7 +68,7 @@ Raw CSV Data → Data Validation → Column Mapping → JSON Transformation → 
 ### 5. Split by Question
 
 - **Purpose**: Create individual JSON files per question for optimized retrieval
-- **Implementation**: File creation in `process_survey_data.ts` and `process_2025_data.ts`
+- **Implementation**: File creation in `process_survey_data.js` and `process_2025_data.js`
 - **Output**:
   - Individual files named `2025_[question_number].json`, `2024_[question_number].json`
   - Located in `scripts/output/split_data/`
@@ -129,10 +129,10 @@ question_1,question_2,region,age_group,gender,org_size
 
 ## Key Scripts
 
-### process_survey_data.ts
+### process_survey_data.js
 
 - **Purpose**: Core data processing script for both 2024 and 2025 data
-- **Location**: `/scripts/process_survey_data.ts`
+- **Location**: `/scripts/process_survey_data.js`
 - **Functionality**:
   - CSV parsing
   - Data validation
@@ -140,10 +140,10 @@ question_1,question_2,region,age_group,gender,org_size
   - JSON transformation
   - File generation
 
-### process_2025_data.ts
+### process_2025_data.js
 
 - **Purpose**: Advanced harmonization and canonical topic mapping for 2025 data
-- **Location**: `/scripts/process_2025_data.ts`
+- **Location**: `/scripts/process_2025_data.js`
 - **Functionality**:
   - Data harmonization across years
   - Canonical topic mapping

--- a/RIA25_Documentation/specification_v2/17_file_function_reference.md
+++ b/RIA25_Documentation/specification_v2/17_file_function_reference.md
@@ -466,8 +466,8 @@ This document provides a comprehensive mapping of all major files and functions 
 
 ## Data Processing Scripts
 
-- `scripts/process_2025_data.ts`: Processes 2025 data
-- `scripts/process_survey_data.ts`: Processes survey data
+- `scripts/process_2025_data.js`: Processes 2025 data
+- `scripts/process_survey_data.js`: Processes survey data
 
 ## Configuration Files
 


### PR DESCRIPTION
## Summary
- update v2 spec docs to reference JavaScript processing scripts
- clarify Node.js script usage in implementation plan

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run lint:css` *(fails: stylelint not found)*