### PR TITLE
Implement cached topic mapping utility

### DIFF
--- a/app/api/services/dataRetrievalService.ts
+++ b/app/api/services/dataRetrievalService.ts
@@ -30,6 +30,7 @@ import { unifiedOpenAIService } from "./unifiedOpenAIService";
 import { migrationMonitor } from "../../../utils/shared/monitoring";
 import { FilterResult } from "../../../utils/data/repository/interfaces/FilterProcessor";
 import OpenAI from 'openai';
+import { getCanonicalMapping } from "../../../utils/data/topicMapping";
 
 // Define our own CompatibilityMetadata type since we can't locate the import
 interface CompatibilityMetadata {
@@ -141,7 +142,7 @@ export class DataRetrievalService {
       fileIdentificationResult.segments || DEFAULT_SEGMENTS;
 
     // Assess compatibility for the identified topics and segments
-    const compatibilityMetadata = this.assessCompatibility(
+    const compatibilityMetadata = await this.assessCompatibility(
       relevantTopics,
       requestedSegments
     );
@@ -181,18 +182,9 @@ export class DataRetrievalService {
    * @param segments - Segment types to check for compatibility
    * @returns Compatibility metadata
    */
-  assessCompatibility(topics: string[], segments: string[]): CompatibilityMetadata {
+  async assessCompatibility(topics: string[], segments: string[]): Promise<CompatibilityMetadata> {
     try {
-      const mappingPath = path.join(
-        process.cwd(),
-        "scripts",
-        "reference files",
-        "2025",
-        "canonical_topic_mapping.json"
-      );
-
-      const mappingData = fs.readFileSync(mappingPath, "utf8");
-      const mapping = JSON.parse(mappingData);
+      const mapping = await getCanonicalMapping();
       const mappingVersion = mapping.metadata?.version || "1.0";
 
       // Initialize compatibility metadata

--- a/utils/data/repository/implementations/PromptRepository.ts
+++ b/utils/data/repository/implementations/PromptRepository.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import logger from '../../../shared/logger';
 import OpenAI from 'openai';
 import kvClient from '../../../cache/kvClient';
+import { getCanonicalMapping } from '../../topicMapping';
 
 // Initialize OpenAI client
 const openai = new OpenAI({
@@ -87,14 +88,7 @@ export default class PromptRepository implements FileRepository {
       const normalizedQuery = query.toLowerCase().trim();
       
       // Load the canonical topic mapping
-      const mappingPath = path.join(
-        process.cwd(),
-        "scripts",
-        "reference files",
-        "2025",
-        "canonical_topic_mapping.json"
-      );
-      const mapping = JSON.parse(fs.readFileSync(mappingPath, "utf8"));
+      const mapping = await getCanonicalMapping();
 
       // --- BEGIN CACHE AWARENESS LOGIC FOR FOLLOW-UPS ---
       let cachedInfoForPromptString = "{}"; // Default to empty JSON object string

--- a/utils/data/topicMapping.ts
+++ b/utils/data/topicMapping.ts
@@ -1,0 +1,27 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+let cachedMapping: any | null = null;
+let loadingPromise: Promise<any> | null = null;
+
+export async function getCanonicalMapping(): Promise<any> {
+  if (cachedMapping) {
+    return cachedMapping;
+  }
+
+  if (!loadingPromise) {
+    const mappingPath = path.join(
+      process.cwd(),
+      'scripts',
+      'reference files',
+      '2025',
+      'canonical_topic_mapping.json'
+    );
+    loadingPromise = fs.readFile(mappingPath, 'utf8').then((data) => {
+      cachedMapping = JSON.parse(data);
+      return cachedMapping;
+    });
+  }
+
+  return loadingPromise;
+}


### PR DESCRIPTION
## Summary
- add `getCanonicalMapping` for lazy loading of canonical topic mapping
- use cached mapping in DataRetrievalService and PromptRepository

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run lint:css` *(fails: stylelint not found)*