### PR TITLE
Improve topic lookup with dictionary

### DIFF
--- a/app/api/services/dataRetrievalService.ts
+++ b/app/api/services/dataRetrievalService.ts
@@ -196,20 +196,9 @@ export class DataRetrievalService {
         assessedAt: Date.now(),
       } as CompatibilityMetadata;
 
-      // Check topic compatibility
+      // Check topic compatibility using the prebuilt dictionary
       for (const topicId of topics) {
-        let foundTopic = null;
-
-        // Find the topic in the mapping
-        for (const theme of mapping.themes || []) {
-          for (const topic of theme.topics || []) {
-            if (topic.id === topicId) {
-              foundTopic = topic;
-              break;
-            }
-          }
-          if (foundTopic) break;
-        }
+        const foundTopic = mapping.topicDict?.[topicId] || null;
 
         if (!foundTopic) {
           // Topic not found in mapping

--- a/tests/topicMapping/topicMapping.test.ts
+++ b/tests/topicMapping/topicMapping.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getCanonicalMapping } from '../../utils/data/topicMapping';
+import { DataRetrievalService } from '../../app/api/services/dataRetrievalService';
+
+describe('canonical mapping utilities', () => {
+  it('builds topic dictionary', async () => {
+    const mapping = await getCanonicalMapping();
+    expect(mapping.topicDict).toBeDefined();
+    expect(mapping.topicDict['Attraction_Factors']).toBeDefined();
+    expect(mapping.topicDict['Attraction_Factors'].id).toBe('Attraction_Factors');
+  });
+
+  it('assesses compatibility using topic dictionary', async () => {
+    const service = new DataRetrievalService();
+    const result = await service.assessCompatibility(['Attraction_Factors'], []);
+    expect(result.topicCompatibility['Attraction_Factors']).toBeDefined();
+    expect(result.topicCompatibility['Attraction_Factors'].comparable).toBe(false);
+  });
+});

--- a/utils/data/topicMapping.ts
+++ b/utils/data/topicMapping.ts
@@ -2,25 +2,51 @@ import fs from 'fs/promises';
 import path from 'path';
 
 let cachedMapping: any | null = null;
+let cachedMtime = 0;
 let loadingPromise: Promise<any> | null = null;
 
+/**
+ * Load the canonical topic mapping with a topic dictionary for quick lookup.
+ * The mapping and dictionary are rebuilt only if the underlying file changes.
+ */
 export async function getCanonicalMapping(): Promise<any> {
-  if (cachedMapping) {
+  const mappingPath = path.join(
+    process.cwd(),
+    'scripts',
+    'reference files',
+    '2025',
+    'canonical_topic_mapping.json'
+  );
+
+  const stat = await fs.stat(mappingPath);
+
+  if (cachedMapping && cachedMtime === stat.mtimeMs) {
     return cachedMapping;
   }
 
   if (!loadingPromise) {
-    const mappingPath = path.join(
-      process.cwd(),
-      'scripts',
-      'reference files',
-      '2025',
-      'canonical_topic_mapping.json'
-    );
-    loadingPromise = fs.readFile(mappingPath, 'utf8').then((data) => {
-      cachedMapping = JSON.parse(data);
-      return cachedMapping;
-    });
+    loadingPromise = fs.readFile(mappingPath, 'utf8')
+      .then((data) => {
+        const mapping = JSON.parse(data);
+
+        // Build topic dictionary for fast lookup
+        const topicDict: Record<string, any> = {};
+        for (const theme of mapping.themes || []) {
+          for (const topic of theme.topics || []) {
+            topicDict[topic.id] = topic;
+          }
+        }
+
+        mapping.topicDict = topicDict;
+
+        cachedMapping = mapping;
+        cachedMtime = stat.mtimeMs;
+
+        return mapping;
+      })
+      .finally(() => {
+        loadingPromise = null;
+      });
   }
 
   return loadingPromise;


### PR DESCRIPTION
## Summary
- create topic dictionary when loading canonical mapping
- use dictionary in compatibility checks
- add regression tests for mapping utilities

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `vitest` not found)*