### PR TITLE
Implement latest year constant

### DIFF
--- a/utils/compatibility/compatibility.ts
+++ b/utils/compatibility/compatibility.ts
@@ -9,6 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 import logger from "../shared/logger";
+import { DEFAULT_LATEST_YEAR } from './constants';
 
 // In-memory cache with TTL
 let compatibilityCache: CompatibilityMapping | null = null;
@@ -624,23 +625,23 @@ export function getComparablePairs(files: FileMetadata[]): ComparablePairsResult
 /**
  * Extract year from file ID
  * @param fileId File ID to extract year from
- * @returns Extracted year or default (2025)
+ * @returns Extracted year or default (DEFAULT_LATEST_YEAR)
  */
 function extractYearFromFileId(fileId: string): number {
   if (fileId.startsWith('2024')) return 2024;
-  if (fileId.startsWith('2025')) return 2025;
+  if (fileId.startsWith(String(DEFAULT_LATEST_YEAR))) return DEFAULT_LATEST_YEAR;
   
   // Try to extract from more complex patterns
   const yearMatch = fileId.match(/^(\d{4})_/);
   if (yearMatch) {
     const year = parseInt(yearMatch[1]);
-    if (year === 2024 || year === 2025) {
+    if (year === 2024 || year === DEFAULT_LATEST_YEAR) {
       return year;
     }
   }
-  
+
   // Default to current year as fallback
-  return 2025;
+  return DEFAULT_LATEST_YEAR;
 }
 
 export default {

--- a/utils/compatibility/constants.ts
+++ b/utils/compatibility/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_LATEST_YEAR = 2025;

--- a/utils/data/repository/adapters/retrieval-adapter.ts
+++ b/utils/data/repository/adapters/retrieval-adapter.ts
@@ -22,6 +22,7 @@ import path from 'path';
 import { DEFAULT_SEGMENTS } from '../../../../utils/cache/segment_keys';
 import { SmartFilteringProcessor } from '../implementations/SmartFiltering';
 import kvClient from '../../../cache/kvClient'; // CORRECTED Import
+import { DEFAULT_LATEST_YEAR } from '../../../../utils/compatibility/constants';
 
 // Import utility functions from the TypeScript implementation
 import {
@@ -143,7 +144,10 @@ export async function identifyRelevantFiles(
           // ====================================
           if (!isComparison) {
             // Always use the latest *numeric* year present in the set
-            const latestYear = numericYears.includes(2025) ? 2025 : Math.max(...numericYears);
+            const latestYear =
+              numericYears.includes(DEFAULT_LATEST_YEAR)
+                ? DEFAULT_LATEST_YEAR
+                : Math.max(...numericYears);
 
             if (isNaN(latestYear)) {
               logger.warn('[COMPATIBILITY GATE] Could not determine latest year – abandoning default-year filter');


### PR DESCRIPTION
## Summary
- centralize latest year constant for compatibility logic
- use the constant in the compatibility module and retrieval adapter

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run lint:css` *(fails: stylelint not found)*