### PR TITLE
Fix auto-scroll when sending new prompt

### DIFF
--- a/app/embed/[assistantId]/page.tsx
+++ b/app/embed/[assistantId]/page.tsx
@@ -548,6 +548,8 @@ function Embed(props) {
       createdAt: new Date(),
       stage: "retrieving",
     });
+    // Reset manual scroll flag so auto-scroll resumes for this new question
+    userScrolledRef.current = false;
 
     try {
       let dataResult;


### PR DESCRIPTION
## Summary
- ensure auto-scroll is re-enabled when submitting a prompt

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run lint:css` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a08224c2c832495bb1c760075d1b9