### PR TITLE
Remove unused NextResponse imports

### DIFF
--- a/app/api/chat-assistant/route.ts
+++ b/app/api/chat-assistant/route.ts
@@ -5,7 +5,7 @@
  * Primary entry point for all assistant interactions.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { postHandler } from '../controllers/chatAssistantController';

--- a/app/api/create-logs-dir/route.ts
+++ b/app/api/create-logs-dir/route.ts
@@ -5,7 +5,7 @@
  * Used for creating log directories on demand.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { postHandler } from "../controllers/createLogsDirController";

--- a/app/api/query/route.ts
+++ b/app/api/query/route.ts
@@ -5,7 +5,7 @@
  * Entry point for standalone query processing in the application.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { postHandler } from "../controllers/queryController";

--- a/app/api/retrieve-data/route.ts
+++ b/app/api/retrieve-data/route.ts
@@ -5,7 +5,7 @@
  * Used for accessing specific data files by ID.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { postHandler } from "../controllers/retrieveDataController";

--- a/app/api/save-to-logs/route.ts
+++ b/app/api/save-to-logs/route.ts
@@ -5,7 +5,7 @@
  * Used for logging client-side events and errors.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { postHandler } from "../controllers/saveToLogsController";

--- a/app/api/test-assistant/route.ts
+++ b/app/api/test-assistant/route.ts
@@ -1,7 +1,7 @@
 // Route handlers for test-assistant API endpoints
 // Delegates business logic to testAssistantController
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { getHandler } from "../controllers/testAssistantController";

--- a/app/api/test-key/route.ts
+++ b/app/api/test-key/route.ts
@@ -1,7 +1,7 @@
 // Route handlers for test-key API endpoints
 // Delegates business logic to testKeyController
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { handleOptions } from "../../../utils/shared/cors";
 import { formatErrorResponse } from "../../../utils/shared/errorHandler";
 import { getHandler } from "../controllers/testKeyController";


### PR DESCRIPTION
## Summary
- drop `NextResponse` from API route imports

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a0e53143c83249f94f8d865a5cec9