### PR TITLE
Remove pollOperation helper

### DIFF
--- a/RIA25_Documentation/specification_v2/17_file_function_reference.md
+++ b/RIA25_Documentation/specification_v2/17_file_function_reference.md
@@ -378,7 +378,6 @@ This document provides a comprehensive mapping of all major files and functions 
       - `poll<T>(pollingFn, config)`: Execute a polling operation with retries and backoff
       - `pollAll<T>(pollingOperations, config)`: Execute multiple polling operations in parallel
   - **Helper Functions**:
-    - `pollOperation<T>(operation, config)`: Convenience function for polling
     - `pollingManager`: Exported singleton instance
 
 ### Monitoring System

--- a/utils/shared/polling-manager.ts
+++ b/utils/shared/polling-manager.ts
@@ -163,11 +163,3 @@ export class PollingManager {
 
 // Export singleton instance
 export const pollingManager = PollingManager.getInstance();
-
-// Export convenience function for polling
-export async function pollOperation<T>(
-  operation: () => Promise<T>,
-  config?: PollingConfig
-): Promise<T> {
-  return pollingManager.poll(operation, config);
-} 


### PR DESCRIPTION
## Summary
- delete `pollOperation` helper function export
- update documentation reference

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a1064b5b48324a42c4e6d7bf45fe0