### PR TITLE
Remove unused thread context helper

### DIFF
--- a/utils/shared/queryUtils.ts
+++ b/utils/shared/queryUtils.ts
@@ -162,24 +162,3 @@ export function extractCleanQueryFromToolCall(toolCallArgs: any): string {
   }
 }
 
-/**
- * Creates a thread context object with normalized queries
- * @param currentQuery Current user query
- * @param previousQuery Previous user query
- * @param previousResponse Previous assistant response
- * @param isFollowUp Whether this is a follow-up query
- * @returns Context object with normalized queries
- */
-export function createThreadContext(
-  currentQuery: string,
-  previousQuery: string,
-  previousResponse: string,
-  isFollowUp: boolean
-) {
-  return {
-    normalizedCurrentQuery: normalizeQueryText(currentQuery),
-    normalizedPreviousQuery: normalizeQueryText(previousQuery),
-    previousResponse,
-    isFollowUp,
-  };
-}


### PR DESCRIPTION
## Summary
- delete `createThreadContext` helper from query utilities

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run lint` *(fails: next not found)*
- `npm run lint:css` *(fails: stylelint not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a12934a1483249091bc4ad0554efe