### PR TITLE
Improve partial compatibility handling

### DIFF
--- a/app/api/controllers/queryController.ts
+++ b/app/api/controllers/queryController.ts
@@ -300,23 +300,28 @@ async function handleComparisonCompatibility(
     
     // Check if we have comparable pairs
     const { valid, invalid, message } = getComparablePairs(mergedFileMetadata);
-    
-    if (invalid.length > 0) {
-      // We have incompatible files, return error
+
+    if (invalid.length > 0 && valid.length === 0) {
+      // All requested files are incompatible
       logger.warn(`[COMPATIBILITY] Incompatible comparison files: ${invalid.join(', ')}`);
       logger.warn(`[COMPATIBILITY] User message: ${message}`);
-      
+
       return {
         error: true,
         message: message || "Year-on-year comparisons are not available for the requested topics due to methodology changes."
       };
     }
-    
-    // We have compatible files, return them
+
+    if (invalid.length > 0) {
+      logger.warn(`[COMPATIBILITY] Partial comparison. Invalid files: ${invalid.join(', ')}`);
+      if (message) logger.warn(`[COMPATIBILITY] User message: ${message}`);
+    }
+
     logger.info(`[COMPATIBILITY] Compatible comparison files: ${valid.join(', ')}`);
     return {
       error: false,
-      fileIds: valid
+      fileIds: valid,
+      message: invalid.length > 0 ? message : undefined
     };
   } catch (error) {
     logger.error(`[COMPATIBILITY] Error handling comparison compatibility: ${error.message}`);

--- a/tests/compatibility/compatGate.test.ts
+++ b/tests/compatibility/compatGate.test.ts
@@ -192,5 +192,37 @@ describe("Compatibility Gate", () => {
       expect(result.valid).toContain("2025_8_1");
       expect(result.message).toBe("");
     });
+
+    it("should retain comparable files in a mixed topic", () => {
+      const fileMetadata: FileMetadata[] = [
+        {
+          fileId: "2024_q1",
+          topicId: "Mixed_Topic",
+          year: 2024,
+          comparable: true,
+          userMessage: "Data is comparable across years for this topic."
+        },
+        {
+          fileId: "2025_q1",
+          topicId: "Mixed_Topic",
+          year: 2025,
+          comparable: false,
+          userMessage: "No comparison"
+        },
+        {
+          fileId: "2025_q2",
+          topicId: "Mixed_Topic",
+          year: 2025,
+          comparable: true,
+          userMessage: "Data is comparable across years for this topic."
+        }
+      ];
+
+      const result = getComparablePairs(fileMetadata);
+
+      expect(result.valid).toContain("2024_q1");
+      expect(result.valid).toContain("2025_q2");
+      expect(result.invalid).toContain("2025_q1");
+    });
   });
-}); 
+});

--- a/utils/compatibility/compatibility.ts
+++ b/utils/compatibility/compatibility.ts
@@ -574,33 +574,21 @@ export function getComparablePairs(files: FileMetadata[]): ComparablePairsResult
     Object.entries(topicGroups).forEach(([topicId, topicFiles]) => {
       // Get all distinct years for this topic
       const years = new Set(topicFiles.map(file => file.year));
-      
-      // Check if topic has both 2024 and 2025 data
+
       if (years.has(2024) && years.has(2025)) {
-        // Get files from each year
-        const files2024 = topicFiles.filter(file => file.year === 2024);
-        const files2025 = topicFiles.filter(file => file.year === 2025);
-        
-        // Check if any file is marked as non-comparable
-        const hasIncomparable = topicFiles.some(file => file.comparable === false);
-        
-        if (hasIncomparable) {
-          // Add all files from this topic to invalid list
-          files2024.concat(files2025).forEach(file => {
+        // Mixed year topic – evaluate each file individually
+        topicFiles.forEach(file => {
+          if (file.comparable) {
+            result.valid.push(file.fileId);
+          } else {
             result.invalid.push(file.fileId);
             if (file.userMessage) {
               userMessages.add(file.userMessage);
             }
-          });
-        } else {
-          // Add all files from this topic to valid list
-          files2024.concat(files2025).forEach(file => {
-            result.valid.push(file.fileId);
-          });
-        }
+          }
+        });
       } else {
         // Topic doesn't have files from both years, so add them all to valid
-        // (this is not a comparison between years)
         topicFiles.forEach(file => {
           result.valid.push(file.fileId);
         });


### PR DESCRIPTION
## Summary
- refine compatibility gate to check files individually instead of whole topics
- return partial results from comparison controller
- test mixed compatibility topics

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683abf601ab48325be805b90d1b53985