### PR TITLE
Fix compatibility warnings for non-comparison queries

### DIFF
--- a/tests/repository/implementations/QueryProcessorImpl.test.ts
+++ b/tests/repository/implementations/QueryProcessorImpl.test.ts
@@ -80,8 +80,19 @@ describe("QueryProcessorImpl", () => {
   describe("isComparisonQuery", () => {
     it("should identify comparison queries correctly", () => {
       expect(queryProcessor.isComparisonQuery("Compare A and B")).toBe(true);
-      expect(queryProcessor.isComparisonQuery("What is the difference between A and B?")).toBe(true);
+      expect(
+        queryProcessor.isComparisonQuery("What is the difference between A and B?")
+      ).toBe(true);
       expect(queryProcessor.isComparisonQuery("Show me A")).toBe(false);
+
+      // New cases for YoY detection improvements
+      expect(queryProcessor.isComparisonQuery("Compare 2024 vs 2025")).toBe(true);
+      expect(
+        queryProcessor.isComparisonQuery("how does this change across countries?")
+      ).toBe(false);
+      expect(
+        queryProcessor.isComparisonQuery("How did this change from last year?")
+      ).toBe(true);
     });
   });
 

--- a/utils/openai/promptUtils.ts
+++ b/utils/openai/promptUtils.ts
@@ -22,6 +22,8 @@ export interface PromptBuildingOptions {
   context?: {
     incomparableTopicMessages?: Record<string, string>;
     hasIncomparableTopics?: boolean;
+    /** Flag indicating this prompt is for a comparison query */
+    isComparisonQuery?: boolean;
   };
   /** Incomparable topic messages directly at root level */
   incomparableTopicMessages?: Record<string, string>;
@@ -291,9 +293,12 @@ export function buildPromptWithFilteredData(
 
   // Add specific incomparable topic messages if any topics were filtered out - do this FIRST
   if (
-    options.incomparableTopicMessages ||
-    (options.context && options.context.incomparableTopicMessages) ||
-    (options.context && options.context.hasIncomparableTopics)
+    (options.context?.isComparisonQuery !== false) &&
+    (
+      options.incomparableTopicMessages ||
+      (options.context && options.context.incomparableTopicMessages) ||
+      (options.context && options.context.hasIncomparableTopics)
+    )
   ) {
     const incomparableTopics =
       options.incomparableTopicMessages ||
@@ -323,7 +328,7 @@ export function buildPromptWithFilteredData(
   }
 
   // Add compatibility information if provided
-  if (options.compatibilityMetadata) {
+  if (options.compatibilityMetadata && options.context?.isComparisonQuery !== false) {
     const compatibilityVerbosity = options.compatibilityVerbosity || "standard";
     
     // If we have incomparable topics and this is a comparison query,


### PR DESCRIPTION
## Summary
- extend `PromptBuildingOptions` to carry `isComparisonQuery`
- ignore incompatible-topic warnings when the current query is not a comparison
- only add compatibility metadata to prompts for comparison queries

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ae51da20c8325b1408e1d464c19e5