### PR TITLE
Remove obsolete shadow mode

### DIFF
--- a/RIA25_Documentation/specification_v2/00_README.md
+++ b/RIA25_Documentation/specification_v2/00_README.md
@@ -1,6 +1,6 @@
 # RIA25 Complete Documentation (v2.0)
 
-**Last Updated:** Sat May 31 09:25:57 UTC 2025
+**Last Updated:** Sat May 31 12:07:48 UTC 2025
 
 This directory contains comprehensive documentation for the full end-to-end development of the RIA25 (Research Insights Assistant 2025) project. This is the **v2.0** update that reflects the major architectural changes implemented through the repository pattern refactoring and TypeScript migration.
 
@@ -145,7 +145,6 @@ The v2.0 documentation incorporates the repository pattern implementation, which
 
    - Unit testing for repository components
    - Integration testing for adapters
-   - Shadow testing for implementation parity
    - TypeScript support in test infrastructure
 
 5. **Migration Strategy**:
@@ -217,4 +216,4 @@ in `RIA25_Documentation/active_plans/`.
 ## Documentation Version
 
 Current documentation version: 2.0  
-_Last updated: Sat May 31 09:25:57 UTC 2025_
+_Last updated: Sat May 31 12:07:48 UTC 2025_

--- a/RIA25_Documentation/specification_v2/06_system_architecture.md
+++ b/RIA25_Documentation/specification_v2/06_system_architecture.md
@@ -1,6 +1,6 @@
 # System Architecture
 
-**Last Updated:** Sat May 31 2025
+**Last Updated:** Sat May 31 12:07:48 UTC 2025
 
 > **Target Audience:** Developers, System Architects, Technical Stakeholders  
 > **Related Documents:**
@@ -176,7 +176,6 @@ The repository pattern implementation consolidates duplicated data retrieval fun
   - `retrieval-adapter.ts`: Adapter for retrieval.js functionality
   - `service-adapter.ts`: Adapter for dataRetrievalService.js
 - **Features**:
-  - Shadow mode for performance comparison
   - Thread-consistent traffic assignment
   - Performance monitoring and metrics
   - Graceful error handling and fallback
@@ -386,7 +385,6 @@ The prompt system evolved to support the new repository pattern architecture:
 
   - Adapter functional testing
   - End-to-end data flow testing
-  - Shadow testing for implementation comparison
   - Performance benchmark testing
 
 - **Compatibility Testing**:
@@ -444,13 +442,11 @@ The repository pattern was implemented in a carefully planned, phased approach t
 
 - **Key Activities**:
   - Implemented adapter layer for existing code
-  - Shadow testing infrastructure
   - Performance monitoring integration
   - Thread-consistent path assignment
 - **Deliverables**:
   - Functional adapters for retrieval.js
   - Metrics collection for comparison
-  - Shadow testing reporting
 - **Technical Solutions**:
   - Set environment flags permanently in repository adapter code:
     - USE_REPOSITORY_PATTERN=true
@@ -601,7 +597,6 @@ The repository pattern was implemented in a carefully planned, phased approach t
 #### 8.3.1 Successes
 
 - Thread-consistent routing proved essential for reliable comparison
-- Shadow testing identified several edge cases before affecting users
 - Performance monitoring provided confidence during migration
 - Phased approach maintained system stability throughout
 
@@ -614,7 +609,6 @@ The repository pattern was implemented in a carefully planned, phased approach t
 
 #### 8.3.3 Best Practices Established
 
-- Always implement shadow testing for critical paths
 - Maintain thread-consistent routing for comparable metrics
 - Establish clear rollback mechanisms before migration
 - Document interfaces comprehensively before implementation
@@ -1024,7 +1018,6 @@ To ensure proper knowledge transfer and maintenance capabilities, the following 
 4. **Testing Guidelines**:
    - Unit testing patterns for repository components
    - Integration testing approaches for adapters
-   - Shadow testing methodology
 
 This documentation ensures that the repository pattern implementation remains maintainable and extensible as the system continues to evolve.
-_Last updated: Sat May 31 2025_
+_Last updated: Sat May 31 12:07:48 UTC 2025_

--- a/RIA25_Documentation/specification_v2/15_thread_data_management.md
+++ b/RIA25_Documentation/specification_v2/15_thread_data_management.md
@@ -1,6 +1,6 @@
 # Thread and Data Cache Management
 
-**Last Updated:** Sat May 31 2025
+**Last Updated:** Sat May 31 12:07:48 UTC 2025
 
 > **Target Audience:** Developers, System Architects  
 > **Related Documents:**
@@ -660,7 +660,6 @@ The system successfully migrated from a file-based cache to Vercel KV while main
 1. **Unified Interface**: Created a common cache interface that could work with both systems
 2. **Gradual Rollout**: Used feature flags for controlled migration
 3. **Thread-Consistent Assignment**: Ensured same thread always used same cache implementation
-4. **Shadow Mode Testing**: Validated Vercel KV with shadow testing before full rollout
 
 ### 8.2 Migration Benefits
 
@@ -769,4 +768,4 @@ The RIA25 thread and cache management system has been significantly enhanced thr
 
 ---
 
-_Last updated: Sat May 31 2025_
+_Last updated: Sat May 31 12:07:48 UTC 2025_

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "repo:status": "node scripts/repository-toggle.js",
-    "repo:shadow": "node scripts/repository-toggle.js shadow",
     "repo:test5": "node scripts/repository-toggle.js test5",
     "repo:test10": "node scripts/repository-toggle.js test10",
     "repo:test25": "node scripts/repository-toggle.js test25",

--- a/scripts/repository-toggle.js
+++ b/scripts/repository-toggle.js
@@ -8,7 +8,6 @@
  *   node scripts/repository-toggle.js [mode]
  *
  * Modes:
- *   - shadow: Shadow mode (logs both implementations, uses original)
  *   - test5: Test mode with 5% traffic
  *   - test10: Test mode with 10% traffic
  *   - test25: Test mode with 25% traffic
@@ -35,65 +34,50 @@ const currentEnv = fs.existsSync(ENV_FILE)
 
 // Available modes with their settings
 const modes = {
-  shadow: {
-    USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "true",
-    REPOSITORY_TRAFFIC_PERCENTAGE: "0",
-    ENABLE_RETRIEVAL_ADAPTER: "true",
-    ENABLE_SERVICE_ADAPTER: "true",
-  },
   test5: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "5",
     ENABLE_RETRIEVAL_ADAPTER: "true",
     ENABLE_SERVICE_ADAPTER: "true",
   },
   test10: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "10",
     ENABLE_RETRIEVAL_ADAPTER: "true",
     ENABLE_SERVICE_ADAPTER: "true",
   },
   test25: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "25",
     ENABLE_RETRIEVAL_ADAPTER: "true",
     ENABLE_SERVICE_ADAPTER: "true",
   },
   test50: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "50",
     ENABLE_RETRIEVAL_ADAPTER: "true",
     ENABLE_SERVICE_ADAPTER: "true",
   },
   full: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "100",
     ENABLE_RETRIEVAL_ADAPTER: "true",
     ENABLE_SERVICE_ADAPTER: "true",
   },
   off: {
     USE_REPOSITORY_PATTERN: "false",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "0",
     ENABLE_RETRIEVAL_ADAPTER: "false",
     ENABLE_SERVICE_ADAPTER: "false",
   },
   retrieval_only: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "100",
     ENABLE_RETRIEVAL_ADAPTER: "true",
     ENABLE_SERVICE_ADAPTER: "false",
   },
   service_only: {
     USE_REPOSITORY_PATTERN: "true",
-    REPOSITORY_SHADOW_MODE: "false",
     REPOSITORY_TRAFFIC_PERCENTAGE: "100",
     ENABLE_RETRIEVAL_ADAPTER: "false",
     ENABLE_SERVICE_ADAPTER: "true",
@@ -131,9 +115,6 @@ function getCurrentMode() {
     return "off";
   }
 
-  if (currentEnv.REPOSITORY_SHADOW_MODE === "true") {
-    return "shadow";
-  }
 
   // Check for adapter-specific modes
   const retrievalEnabled = currentEnv.ENABLE_RETRIEVAL_ADAPTER === "true";

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Assistant Tests
 
-**Last Updated:** Tue May 6 2025
+**Last Updated:** Sat May 31 12:07:48 UTC 2025
 
 This directory contains test scripts for evaluating different aspects of the application.
 
@@ -75,7 +75,6 @@ The repository pattern has been fully implemented with a gradual rollout strateg
 3. **Feature Flag System**:
 
    - Environment variable: USE_REPOSITORY_PATTERN
-   - Shadow mode: REPOSITORY_SHADOW_MODE
    - Traffic percentage: REPOSITORY_TRAFFIC_PERCENTAGE
 
 4. **Monitoring System**:
@@ -89,7 +88,6 @@ The repository pattern implementation includes a toggle script for controlling t
 
 ```bash
 npm run repo:status      # Check current rollout status
-npm run repo:shadow      # Enable shadow mode (log both implementations)
 npm run repo:test5       # Test with 5% traffic
 npm run repo:test10      # Test with 10% traffic
 npm run repo:test25      # Test with 25% traffic
@@ -166,18 +164,16 @@ OpenAI tests use these environment variables from the root `.env` file:
 Repository pattern uses these environment variables:
 
 - `USE_REPOSITORY_PATTERN` - Main feature flag for repository pattern (true/false)
-- `REPOSITORY_SHADOW_MODE` - Enable shadow mode to run both implementations (true/false)
 - `REPOSITORY_TRAFFIC_PERCENTAGE` - Percentage of traffic to route through repository (0-100)
 
 ## Rollout Strategy
 
 The repository pattern implementation follows a phased rollout approach:
 
-1. **Shadow Mode**: Run both implementations, compare results, use original
-2. **Limited Testing**: Route small percentage of traffic (5-10%) through repository
-3. **Expanded Testing**: Increase traffic allocation (25-50%)
-4. **Full Implementation**: Switch all traffic to repository pattern implementation
-5. **Cleanup**: Remove original implementation code after stable period
+1. **Limited Testing**: Route small percentage of traffic (5-10%) through repository
+2. **Expanded Testing**: Increase traffic allocation (25-50%)
+3. **Full Implementation**: Switch all traffic to repository pattern implementation
+4. **Cleanup**: Remove original implementation code after stable period
 
 
-_Last updated: Sat May 31 11:29:40 UTC 2025_
+_Last updated: Sat May 31 12:07:48 UTC 2025_

--- a/utils/data/repository/adapters/retrieval-adapter.ts
+++ b/utils/data/repository/adapters/retrieval-adapter.ts
@@ -34,7 +34,6 @@ import {
  */
 // Setting environment variables directly in code
 const USE_REPOSITORY_PATTERN = true; // Forced to true
-const SHADOW_MODE = false; // Disabled shadow mode
 const TRAFFIC_PERCENTAGE = 100; // 100% traffic to repository
 const ENABLE_RETRIEVAL_ADAPTER = true; // Forced to true
 

--- a/utils/data/repository/adapters/service-adapter.ts
+++ b/utils/data/repository/adapters/service-adapter.ts
@@ -22,7 +22,6 @@ import logger from '../../../shared/logger';
  * Feature flags and rollout configuration
  */
 const USE_REPOSITORY_PATTERN = process.env.USE_REPOSITORY_PATTERN === 'true';
-const SHADOW_MODE = process.env.REPOSITORY_SHADOW_MODE === 'true';
 const TRAFFIC_PERCENTAGE = parseInt(process.env.REPOSITORY_TRAFFIC_PERCENTAGE || '0', 10);
 const ENABLE_SERVICE_ADAPTER = process.env.ENABLE_SERVICE_ADAPTER === 'true';
 
@@ -108,11 +107,10 @@ export async function identifyRelevantFiles(
 ) {
   // Determine if this request should use repository implementation
   const useRepository = shouldUseRepositoryImplementation(options.threadId);
-  const isShadowMode = SHADOW_MODE && USE_REPOSITORY_PATTERN;
+
+  logger.info(`[ADAPTER] Service identifyRelevantFiles called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%`);
   
-  logger.info(`[ADAPTER] Service identifyRelevantFiles called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%, shadow: ${isShadowMode}`);
-  
-  // Always run original implementation in shadow mode or when feature flag is off
+  // Always run original implementation when feature flag is off
   // Track original implementation performance
   
   let originalResult;
@@ -131,8 +129,8 @@ export async function identifyRelevantFiles(
     throw error; // Re-throw if we're not using the repository as fallback
   }
   
-  // If not using repository implementation and not in shadow mode, return original result
-  if (!useRepository && !isShadowMode) {
+  // If not using repository implementation, return original result
+  if (!useRepository) {
     return originalResult;
   }
   
@@ -162,13 +160,7 @@ export async function identifyRelevantFiles(
     // Call repository method
       const repoResult = await repository.getFilesByQuery(context);
     
-    // In shadow mode, log comparison but return original result
-    if (isShadowMode) {
-      logger.info(`[SHADOW] service.identifyRelevantFiles comparison - original: ${originalResult.length} files, repository: ${repoResult.relevantFiles.length} files`);
-      return originalResult;
-    }
-    
-    // Otherwise return repository result
+    // Return repository result
     return repoResult.relevantFiles;
     } catch (error) {
       logger.error(`[ADAPTER] Error in repository service.identifyRelevantFiles: ${error.message}`);
@@ -193,11 +185,9 @@ export async function loadDataFiles(
 ) {
   // Determine if this request should use repository implementation
   const useRepository = shouldUseRepositoryImplementation();
-  const isShadowMode = SHADOW_MODE && USE_REPOSITORY_PATTERN;
+  logger.info(`[ADAPTER] Service loadDataFiles called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%`);
   
-  logger.info(`[ADAPTER] Service loadDataFiles called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%, shadow: ${isShadowMode}`);
-  
-  // Always run original implementation in shadow mode or when feature flag is off
+  // Always run original implementation when feature flag is off
   let originalResult;
   try {
     const service = await getOriginalService();
@@ -207,8 +197,8 @@ export async function loadDataFiles(
     throw error; // Re-throw if we're not using the repository as fallback
   }
   
-  // If not using repository implementation and not in shadow mode, return original result
-  if (!useRepository && !isShadowMode) {
+  // If not using repository implementation, return original result
+  if (!useRepository) {
     return originalResult;
   }
   
@@ -223,13 +213,7 @@ export async function loadDataFiles(
     // Call repository method
       const repoResult = await repository.getFilesByIds(fileIds);
     
-    // In shadow mode, log comparison but return original result
-    if (isShadowMode) {
-      logger.info(`[SHADOW] service.loadDataFiles comparison - original: ${originalResult.length} files, repository: ${repoResult.length} files`);
-      return originalResult;
-    }
-    
-    // Otherwise return repository result
+    // Return repository result
     return repoResult;
     } catch (error) {
       logger.error(`[ADAPTER] Error in repository service.loadDataFiles: ${error.message}`);
@@ -254,11 +238,10 @@ export async function processQueryWithData(
 ) {
   // Determine if this request should use repository implementation
   const useRepository = shouldUseRepositoryImplementation(options.threadId);
-  const isShadowMode = SHADOW_MODE && USE_REPOSITORY_PATTERN;
+
+  logger.info(`[ADAPTER] Service processQueryWithData called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%`);
   
-  logger.info(`[ADAPTER] Service processQueryWithData called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%, shadow: ${isShadowMode}`);
-  
-  // Always run original implementation in shadow mode or when feature flag is off
+  // Always run original implementation when feature flag is off
   // Track original implementation performance
   
   let originalResult;
@@ -279,8 +262,8 @@ export async function processQueryWithData(
     throw error; // Re-throw if we're not using the repository as fallback
   }
   
-  // If not using repository implementation and not in shadow mode, return original result
-  if (!useRepository && !isShadowMode) {
+  // If not using repository implementation, return original result
+  if (!useRepository) {
     return originalResult;
   }
   
@@ -318,13 +301,7 @@ export async function processQueryWithData(
     
     const result = await processor.processQueryWithData(context, processingOptions);
     
-    // In shadow mode, log comparison but return original result
-    if (isShadowMode) {
-      logger.info(`[SHADOW] service.processQueryWithData comparison - original: ${Object.keys(originalResult).length} properties, repository: ${Object.keys(result).length} properties`);
-      return originalResult;
-    }
-    
-    // Otherwise return repository result
+    // Return repository result
     return {
       ...result,
       // Add information about missing/available segments
@@ -357,11 +334,10 @@ export async function cacheFilesForThread(
 ) {
   // Determine if this request should use repository implementation
   const useRepository = shouldUseRepositoryImplementation(threadId);
-  const isShadowMode = SHADOW_MODE && USE_REPOSITORY_PATTERN;
+
+  logger.info(`[ADAPTER] Service cacheFilesForThread called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%`);
   
-  logger.info(`[ADAPTER] Service cacheFilesForThread called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%, shadow: ${isShadowMode}`);
-  
-  // Always run original implementation in shadow mode or when feature flag is off
+  // Always run original implementation when feature flag is off
   // Track original implementation performance
   
   let originalResult = false;
@@ -374,8 +350,8 @@ export async function cacheFilesForThread(
     // Original implementation failed, don't rethrow as we'll try repository if enabled
   }
   
-  // If not using repository implementation and not in shadow mode, return original result
-  if (!useRepository && !isShadowMode) {
+  // If not using repository implementation, return original result
+  if (!useRepository) {
     return originalResult;
   }
   
@@ -395,13 +371,7 @@ export async function cacheFilesForThread(
     
     const result = await cacheManager.setThreadFiles(threadId, fileIds);
     
-    // In shadow mode, log comparison but return original result
-    if (isShadowMode) {
-      logger.info(`[SHADOW] service.cacheFilesForThread comparison - original: ${originalResult}, repository: ${result}`);
-      return originalResult;
-    }
-    
-    // Otherwise return repository result
+    // Return repository result
     return result;
   } catch (error) {
     logger.error(`[ADAPTER] Error in repository service.cacheFilesForThread: ${error.message}`);
@@ -424,11 +394,10 @@ export async function getCachedFilesForThread(
 ) {
   // Determine if this request should use repository implementation
   const useRepository = shouldUseRepositoryImplementation(threadId);
-  const isShadowMode = SHADOW_MODE && USE_REPOSITORY_PATTERN;
+
+  logger.info(`[ADAPTER] Service getCachedFilesForThread called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%`);
   
-  logger.info(`[ADAPTER] Service getCachedFilesForThread called with feature flag: ${USE_REPOSITORY_PATTERN}, traffic: ${TRAFFIC_PERCENTAGE}%, shadow: ${isShadowMode}`);
-  
-  // Always run original implementation in shadow mode or when feature flag is off
+  // Always run original implementation when feature flag is off
   // Track original implementation performance
   
   let originalResult = [];
@@ -441,8 +410,8 @@ export async function getCachedFilesForThread(
     // Original implementation failed, don't rethrow as we'll try repository if enabled
   }
   
-  // If not using repository implementation and not in shadow mode, return original result
-  if (!useRepository && !isShadowMode) {
+  // If not using repository implementation, return original result
+  if (!useRepository) {
     return originalResult;
   }
   
@@ -462,13 +431,7 @@ export async function getCachedFilesForThread(
     
     const cachedFiles = await cacheManager.getThreadFiles(threadId);
     
-    // In shadow mode, log comparison but return original result
-    if (isShadowMode) {
-      logger.info(`[SHADOW] service.getCachedFilesForThread comparison - original: ${originalResult.length} files, repository: ${cachedFiles.length} files`);
-      return originalResult;
-    }
-    
-    // Otherwise return repository result
+    // Return repository result
     return cachedFiles;
   } catch (error) {
     logger.error(`[ADAPTER] Error in repository service.getCachedFilesForThread: ${error.message}`);


### PR DESCRIPTION
## Summary
- delete shadow mode flag usage
- prune shadow references from repository toggle script and docs
- remove repo:shadow npm script
- tidy adapters after flag removal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683af034de208325a37d51614f2d43bc