### PR TITLE
Use data-driven topic mapping

### DIFF
--- a/app/api/controllers/retrieveDataController.ts
+++ b/app/api/controllers/retrieveDataController.ts
@@ -12,6 +12,7 @@ import path from "path";
 import logger from "../../../utils/shared/logger";
 import { unifiedOpenAIService } from "../services/unifiedOpenAIService";
 import { isFeatureEnabled } from "../../../utils/shared/feature-flags";
+import { getTopicForFileId } from "../../../utils/data/topicMapping";
 
 export async function postHandler(request) {
   const startTime = Date.now();
@@ -48,12 +49,7 @@ export async function postHandler(request) {
           const fileContent = await fs.readFile(filePath, "utf8");
           const jsonData = JSON.parse(fileContent);
 
-          let topic = "Unknown";
-          if (file_id.includes("_1")) topic = "Attraction_Factors";
-          else if (file_id.includes("_2")) topic = "Retention_Factors";
-          else if (file_id.includes("_3")) topic = "Attrition_Factors";
-          else if (file_id.includes("_7")) topic = "Intention_to_Leave";
-          else if (file_id.includes("_12")) topic = "Work_Preferences";
+          const topic = getTopicForFileId(file_id);
 
           topics.add(topic);
           

--- a/utils/data/topicMapping.ts
+++ b/utils/data/topicMapping.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import logger from '../shared/logger';
+
+interface TopicMapping {
+  themes: Array<{
+    topics: Array<{
+      id: string;
+      mapping: Record<string, Array<{ file: string }>>;
+    }>;
+  }>;
+}
+
+let cachedMapping: TopicMapping | null = null;
+
+function loadMapping(): TopicMapping {
+  if (cachedMapping) {
+    return cachedMapping;
+  }
+  try {
+    const mappingPath = path.join(
+      process.cwd(),
+      'scripts',
+      'reference files',
+      '2025',
+      'canonical_topic_mapping.json'
+    );
+    const raw = fs.readFileSync(mappingPath, 'utf8');
+    cachedMapping = JSON.parse(raw);
+    logger.info(`[TOPIC_MAPPING] Loaded mapping from ${mappingPath}`);
+    return cachedMapping as TopicMapping;
+  } catch (error) {
+    logger.error(`[TOPIC_MAPPING] Failed to load mapping: ${(error as Error).message}`);
+    throw error;
+  }
+}
+
+export function getTopicForFileId(fileId: string): string {
+  const mapping = loadMapping();
+  const normalized = fileId.endsWith('.json') ? fileId : `${fileId}.json`;
+
+  for (const theme of mapping.themes || []) {
+    for (const topic of theme.topics || []) {
+      for (const year of Object.keys(topic.mapping || {})) {
+        const entries = topic.mapping[year] || [];
+        for (const entry of entries) {
+          if (entry.file === normalized) {
+            return topic.id;
+          }
+        }
+      }
+    }
+  }
+  return 'Unknown';
+}


### PR DESCRIPTION
## Summary
- centralize topic lookup in a cached mapping loader
- refactor `retrieveDataController` to use the mapping

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683afae9447c8325a07e4ecee19d15e3