### PR TITLE
Dynamic year detection for comparison checks

### DIFF
--- a/utils/compatibility/compatibility.ts
+++ b/utils/compatibility/compatibility.ts
@@ -641,6 +641,29 @@ export function summarizeTopicFiles(files: FileMetadata[]): Record<string, { yea
 }
 
 /**
+ * Get all distinct years present in the compatibility mapping
+ * @returns Sorted array of years
+ */
+export function getAvailableYears(): number[] {
+  try {
+    const mapping = loadCompatibilityMapping();
+    const years = new Set<number>();
+
+    Object.keys(mapping.files).forEach((fileId) => {
+      const match = fileId.match(/^(\d{4})/);
+      if (match) {
+        years.add(parseInt(match[1], 10));
+      }
+    });
+
+    return Array.from(years).sort();
+  } catch (error) {
+    logger.error(`Error getting available years: ${(error as Error).message}`);
+    return [];
+  }
+}
+
+/**
  * Extract year from file ID
  * @param fileId File ID to extract year from
  * @returns Extracted year or default (2025)
@@ -676,7 +699,8 @@ export default {
   getFileIncomparabilityReason,
   lookupFiles,
   getComparablePairs,
-  summarizeTopicFiles
+  summarizeTopicFiles,
+  getAvailableYears
 };
 
 // Last updated: Sat May 31 12:26:45 UTC 2025


### PR DESCRIPTION
## Summary
- derive available years from compatibility mapping
- extract years from query using dynamic list
- integrate dynamic years into comparison compatibility logic

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test:unit` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b019deff483259129986b83a72f3c