### PR TITLE
Remove unused FileSystemRepository imports

### DIFF
--- a/utils/data/repository/adapters/retrieval-adapter.ts
+++ b/utils/data/repository/adapters/retrieval-adapter.ts
@@ -14,7 +14,7 @@
  */
 
 import { QueryProcessor, QueryContext, DataFile } from '../interfaces';
-import { FileSystemRepository, QueryProcessorImpl, PromptRepository } from '../implementations';
+import { QueryProcessorImpl, PromptRepository } from '../implementations';
 import logger from '../../../shared/logger';
 import { QueryContext as QueryContextImpl } from '../implementations/QueryContext';
 import path from 'path';

--- a/utils/data/repository/adapters/service-adapter.ts
+++ b/utils/data/repository/adapters/service-adapter.ts
@@ -14,7 +14,7 @@
  */
 
 import { FileRepository, QueryProcessor, QueryContext, SegmentTrackingData } from '../interfaces';
-import { FileSystemRepository, QueryProcessorImpl, PromptRepository } from '../implementations';
+import { QueryProcessorImpl, PromptRepository } from '../implementations';
 import { ThreadCacheManager } from '../implementations/ThreadCacheManager';
 import logger from '../../../shared/logger';
 


### PR DESCRIPTION
## Summary
- drop unused FileSystemRepository import from retrieval adapter
- drop the same unused import from service adapter

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test:unit` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b01a940b88325b668742be84f54b9