### PR TITLE
Refactor starter question util

### DIFF
--- a/RIA25_Documentation/specification_v2/17_file_function_reference.md
+++ b/RIA25_Documentation/specification_v2/17_file_function_reference.md
@@ -141,7 +141,7 @@ This document provides a comprehensive mapping of all major files and functions 
 - `app/api/services/dataRetrievalService.ts`
   - `processQueryWithData(query, context, cachedFileIds, threadId, isFollowUp, previousQuery, previousResponse)`: Orchestrates data processing
   - `getPrecompiledStarterData(code)`: Retrieves starter question data
-  - `isStarterQuestion(prompt)`: Detects starter question codes
+  - `isStarterQuestion(query)`: Detects starter question codes or general starter queries
   - `getCachedFiles(threadId)`: Gets cached files using the CacheRepository
   - `updateThreadCache(threadId, fileIds)`: Updates cached files using the CacheRepository
 - `app/api/services/queryService.ts`

--- a/utils/data/repository/implementations/QueryProcessorImpl.ts
+++ b/utils/data/repository/implementations/QueryProcessorImpl.ts
@@ -30,6 +30,7 @@ import {
 } from './SmartFiltering';
 import { QueryIntent, FilterResult } from '../interfaces/FilterProcessor';
 import logger from '../../../shared/logger';
+import { isStarterQuestion as detectStarterQuestion } from '../../../shared/queryUtils';
 
 /**
  * Implementation of the QueryProcessor interface
@@ -216,45 +217,7 @@ export default class QueryProcessorImpl implements QueryProcessor {
    * @returns Whether the query is a starter question
    */
   isStarterQuestion(query: string): boolean {
-    if (!query) return false;
-    
-    // Normalize the query
-    const normalizedQuery = query.toLowerCase().trim();
-    
-    // Starter question patterns
-    const starterPatterns = [
-      /\bwhat are\b.*\bkey\b|\bimportant\b|\bmain\b.*\b(points|topics|facts|insights|findings)\b/i,
-      /\bwhat is\b.*\boverview\b/i,
-      /\bgive me an overview\b/i,
-      /\bsummarize\b/i,
-      /\bsummary\b/i,
-      /\bhighlights\b/i,
-      /\bwhat should i know\b/i,
-      /\bwhat do i need to know\b/i,
-      /\btell me about\b/i,
-      /\btell me more\b/i,
-      /\bintroduction\b/i,
-      /\bintroduce me\b/i,
-      /\bexplain\b/i,
-      /\bwhat are\b/i,
-      /\bhow would you describe\b/i,
-      /\bprovide context\b/i,
-    ];
-    
-    // Check for starter patterns
-    for (const pattern of starterPatterns) {
-      if (pattern.test(normalizedQuery)) {
-        return true;
-      }
-    }
-    
-    // Short queries (less than 5 words) are often general questions
-    const wordCount = normalizedQuery.split(/\s+/).filter(Boolean).length;
-    if (wordCount < 5) {
-      return true;
-    }
-    
-    return false;
+    return detectStarterQuestion(query);
   }
 
   /**

--- a/utils/openai/starterHelpers.ts
+++ b/utils/openai/starterHelpers.ts
@@ -10,6 +10,7 @@
 import fs from 'fs';
 import path from 'path';
 import logger from '../shared/logger';
+import { isStarterQuestion } from '../shared/queryUtils';
 
 // Directory for precompiled starter data
 const PRECOMPILED_STARTERS_DIR = path.join(
@@ -80,17 +81,7 @@ export function getPrecompiledStarterData(code: string): any | null {
  * @param {string} prompt - The prompt or code to check
  * @returns {boolean} True if the prompt matches the starter question code pattern
  */
-export function isStarterQuestion(prompt: string): boolean {
-  if (!prompt || typeof prompt !== "string") {
-    return false;
-  }
-
-  const trimmed = prompt.trim();
-  // Simple regex to match SQ followed by one or more digits
-  const result = /^SQ\d+$/i.test(trimmed);
-  
-  return result;
-}
+export { isStarterQuestion };
 
 /**
  * Checks if a query is asking for a comparison between years

--- a/utils/shared/queryUtils.ts
+++ b/utils/shared/queryUtils.ts
@@ -85,23 +85,49 @@ export function normalizeQuery(query: string): string {
  */
 export function isStarterQuestion(query: string): boolean {
   if (!query) return false;
-  
+
   const normalizedQuery = query.toLowerCase().trim();
-  
-  // Short queries likely to be starters
-  if (normalizedQuery.length < 15) return true;
-  
-  // Common starter patterns
+
+  // Check for starter question codes like "SQ1"
+  if (/^sq\d+$/i.test(normalizedQuery)) {
+    return true;
+  }
+
+  // Short queries are generally introductory
+  if (normalizedQuery.length < 15) {
+    return true;
+  }
+
   const starterPatterns = [
     /^(hi|hello|hey)/i,
     /^what can you/i,
     /^tell me about/i,
     /^help me/i,
     /^what do you know/i,
-    /^what can i ask/i
+    /^what can i ask/i,
+    /\bwhat are\b.*\bkey\b|\bimportant\b|\bmain\b.*\b(points|topics|facts|insights|findings)\b/i,
+    /\bwhat is\b.*\boverview\b/i,
+    /\bgive me an overview\b/i,
+    /\bsummarize\b/i,
+    /\bsummary\b/i,
+    /\bhighlights\b/i,
+    /\bwhat should i know\b/i,
+    /\bwhat do i need to know\b/i,
+    /\btell me more\b/i,
+    /\bintroduction\b/i,
+    /\bintroduce me\b/i,
+    /\bexplain\b/i,
+    /\bwhat are\b/i,
+    /\bhow would you describe\b/i,
+    /\bprovide context\b/i
   ];
-  
-  return starterPatterns.some(pattern => pattern.test(normalizedQuery));
+
+  if (starterPatterns.some((pattern) => pattern.test(normalizedQuery))) {
+    return true;
+  }
+
+  const wordCount = normalizedQuery.split(/\s+/).filter(Boolean).length;
+  return wordCount < 5;
 }
 
 /**


### PR DESCRIPTION
## Summary
- merge the two `isStarterQuestion` implementations
- re-export unified helper from `starterHelpers`
- delegate `QueryProcessorImpl` to the shared util
- clarify docs about unified function

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b01ace4208325b4e5196ac6a5a530