### PR TITLE
Fix docs: disallow cross-segmentation

### DIFF
--- a/RIA25_Documentation/specification_v2/01_project_overview.md
+++ b/RIA25_Documentation/specification_v2/01_project_overview.md
@@ -1,6 +1,6 @@
 # RIA25 Project Overview
 
-**Last Updated:** Tue May 6 11:15:20 BST 2025
+**Last Updated:** Sat May 31 14:15:59 UTC 2025
 
 > **Target Audience:** Developers, Stakeholders, Project Managers  
 > **Related Documents:**
@@ -122,7 +122,7 @@ interface CacheManager {
 - **Repository Pattern**: Clean separation of concerns through interfaces and implementations
 - **TypeScript Migration**: Enhanced type safety and developer experience
 - **Vercel KV Integration**: Performance optimization with Redis-based caching
-- **Two-Segment Rule**: Prevents invalid cross-segmentation of demographic data
+- **Single-Segment Restriction**: Prevents combining multiple demographic dimensions in a single analysis
 - **Anti-Fabrication Measures**: Ensures AI does not generate fictional data
 - **Canonical Topic Mapping**: Dynamic mapping of user queries to canonical survey topics
 - **Selective Year-over-Year Comparison**: Rules-based approach for valid comparisons
@@ -159,4 +159,4 @@ RIA25 v2 aims to:
 
 ---
 
-_Last updated: Tue May 6 11:15:20 BST 2025_
+_Last updated: Sat May 31 14:15:59 UTC 2025_

--- a/RIA25_Documentation/specification_v2/02_implementation_plan.md
+++ b/RIA25_Documentation/specification_v2/02_implementation_plan.md
@@ -1,6 +1,6 @@
 # RIA25 Implementation Plan
 
-**Last Updated:** Sat May 31 2025
+**Last Updated:** Sat May 31 14:15:59 UTC 2025
 
 > **Target Audience:** Developers, System Architects, Technical Stakeholders  
 > **Related Documents:**
@@ -289,10 +289,10 @@ This approach was chosen over alternatives (single large JSON file, database) fo
 
 ### Segment Handling
 
-The implementation enforces a two-segment maximum rule:
+The implementation prohibits combining multiple demographic segments:
 
-- Prevents invalid cross-segmentation
-- Maintains statistical validity
+- Prevents invalid cross-segmentation entirely
+- Maintains statistical validity by using single-dimension statistics only
 - Ensures response accuracy
 
 ### API Integration
@@ -311,7 +311,7 @@ OpenAI Assistants API was selected over alternatives due to:
 | Legacy code interdependencies       | Phased repository pattern implementation             |
 | TypeScript migration complexity     | Interface-first approach with incremental conversion |
 | File-based caching limitations      | Vercel KV integration with standardized key schema   |
-| Cross-segmentation validity         | Two-segment rule enforcement with repository pattern |
+| Cross-segmentation validity         | Single-segment restriction enforcement with repository pattern |
 | Compatibility validation            | Unified compatibility gate in repository layer       |
 | Development environment consistency | Local fallbacks for Vercel KV and other services     |
 | Code quality and type safety        | Comprehensive TypeScript interfaces and testing      |
@@ -344,4 +344,4 @@ The v2 architecture has delivered significant performance improvements:
 
 ---
 
-_Last updated: Sat May 31 2025_
+_Last updated: Sat May 31 14:15:59 UTC 2025_

--- a/RIA25_Documentation/specification_v2/09_development_timeline.md
+++ b/RIA25_Documentation/specification_v2/09_development_timeline.md
@@ -1,6 +1,6 @@
 # RIA25 Development Timeline
 
-**Last Updated:** Tue May 13 14:45:21 BST 2025
+**Last Updated:** Sat May 31 14:15:59 UTC 2025
 
 > **Target Audience:** Developers, Project Managers, System Architects  
 > **Related Documents:**
@@ -61,7 +61,7 @@ This document chronicles the development of RIA25, capturing key milestones, cha
 - Segment detection rules implementation
 - Anti-fabrication measures testing
 - Response formatting guidelines
-- **Decision**: Implemented two-segment rule for demographic cross-sectioning
+- **Decision**: Implemented single-segment restriction for demographic cross-sectioning
 
 ### Testing and Optimization Phase (Q3-Q4 2024)
 
@@ -191,7 +191,7 @@ The repository pattern migration was implemented in five distinct phases:
 | Challenge                     | Solution                           | Impact                                                 |
 | ----------------------------- | ---------------------------------- | ------------------------------------------------------ |
 | CSV format inconsistencies    | Dynamic column mapping             | Resilient data processing regardless of format changes |
-| Cross-segmentation validity   | Two-segment rule enforcement       | Prevented statistically invalid combinations           |
+| Cross-segmentation validity   | Single-segment restriction enforcement       | Prevented statistically invalid combinations           |
 | Response fabrication          | Multi-layered verification prompts | Significant reduction in AI hallucinations             |
 | Vector retrieval accuracy     | Question-specific JSON files       | Improved relevance of retrieved context                |
 | Code duplication              | Repository pattern implementation  | Unified data access with consistent interfaces         |
@@ -341,4 +341,4 @@ Based on the current implementation status, the following priorities are recomme
 
 ---
 
-_Last updated: Tue May 13 14:45:21 BST 2025_
+_Last updated: Sat May 31 14:15:59 UTC 2025_

--- a/RIA25_Documentation/specification_v2/10_testing_methodology.md
+++ b/RIA25_Documentation/specification_v2/10_testing_methodology.md
@@ -1,6 +1,6 @@
 # RIA25 Testing Methodology
 
-**Last Updated:** Tue May 6 11:21:44 BST 2025
+**Last Updated:** Sat May 31 14:15:59 UTC 2025
 
 > **Target Audience:** Developers, QA Engineers, System Architects  
 > **Related Documents:**
@@ -317,7 +317,7 @@ describe("VercelKVCacheManager", () => {
 2. **Cross-Demographic Queries**: Testing handling of queries across multiple demographics
 
    - Example: "How did responses to Question 5 differ between men and women in APAC?"
-   - Success Criteria: Correct data or appropriate limiting of cross-segmentation
+   - Success Criteria: Correct data or an explanation that cross-segmentation is unsupported
 
 3. **Trend Analysis Queries**: Testing year-over-year comparison capabilities
    - Example: "How did responses to Question 10 change from 2024 to 2025?"
@@ -779,7 +779,7 @@ Planned testing improvements include:
 2. **Mock Repository Limitations**: Mock repositories cannot replicate all real-world edge cases
 3. **TypeScript Runtime Type Erasure**: Type safety only guaranteed at compile time
 4. **AI Response Variability**: Assistant responses can vary slightly even with identical inputs
-5. **Multiple Segment Limitation**: System intentionally limits cross-segmentation to two demographic dimensions
+5. **Single-Segment Limitation**: System does not support combining multiple demographic dimensions
 
 ## Continuous Improvement Approach
 
@@ -793,4 +793,4 @@ Planned testing improvements include:
 
 ---
 
-_Last updated: Tue May 6 11:21:44 BST 2025_
+_Last updated: Sat May 31 14:15:59 UTC 2025_

--- a/RIA25_Documentation/specification_v2/16_glossary.md
+++ b/RIA25_Documentation/specification_v2/16_glossary.md
@@ -1,6 +1,6 @@
 # RIA25 Glossary
 
-**Last Updated:** Tue May 13 10:15:47 BST 2025
+**Last Updated:** Sat May 31 14:15:59 UTC 2025
 
 > **Target Audience:** Developers, Data Scientists, Content Specialists  
 > **Related Documents:**
@@ -217,9 +217,9 @@ The architectural layer that contains business logic and orchestrates operations
 
 Categorical groupings of canonical topics in the mapping file, such as "Talent Attraction & Retention" or "Skills & Development".
 
-#### Two-Segment Rule
+#### Single-Segment Restriction
 
-A design principle in RIA25 that limits cross-segmentation analysis to a maximum of two demographic dimensions to maintain statistical validity.
+A design principle in RIA25 that disallows cross-segmentation. Analysis can only use one demographic dimension at a time to maintain statistical validity.
 
 #### Topic-Centric Structure
 
@@ -333,4 +333,4 @@ For more detailed information on specific topics, refer to:
 
 ---
 
-_Last updated: Tue May 13 10:15:47 BST 2025_
+_Last updated: Sat May 31 14:15:59 UTC 2025_

--- a/RIA25_Documentation/specification_v2/RIA25_System_Overview_Non_Technical.md
+++ b/RIA25_Documentation/specification_v2/RIA25_System_Overview_Non_Technical.md
@@ -1,6 +1,6 @@
 # RIA25 System Overview for Non-Technical Users
 
-**Last Updated:** Tue May 13 16:00:45 BST 2025
+**Last Updated:** Sat May 31 14:15:59 UTC 2025
 
 > **Target Audience:** Business Stakeholders, Non-Technical Users, Content Specialists
 
@@ -133,13 +133,12 @@ RIA25 is designed to prevent making up information that isn't supported by the s
 - It won't generate fictional trends or numbers
 - It maintains the statistical integrity of the original research
 
-### Two-Segment Rule
+### Single-Segment Restriction
 
-To ensure statistical validity, RIA25 follows a two-segment rule:
+RIA25 does not support cross-segmenting multiple demographic dimensions:
 
-- Data can be filtered by a maximum of two demographic dimensions at once
-- This prevents creating segments with sample sizes too small for reliable analysis
-- For example, you can filter by "region and age" but not "region, age, and gender" simultaneously
+- Data can only be filtered by **one** demographic dimension at a time
+- Combining dimensions like "region and age" is not possible because the dataset only contains single-dimension statistics
 
 ### Year Compatibility Checking
 
@@ -242,4 +241,4 @@ Here are some effective questions to start with:
 
 ---
 
-_Last updated: Tue May 13 16:00:45 BST 2025_
+_Last updated: Sat May 31 14:15:59 UTC 2025_

--- a/public/prompt_files/1_data_retrieval.md
+++ b/public/prompt_files/1_data_retrieval.md
@@ -78,7 +78,7 @@ After analyzing the query, you must review the entire file to:
    - Apply case-insensitive matching and core concept extraction to map query keywords to canonical topics or their alternate phrasings.
    - Do not invent any topics—use only those in the mapping.
 
-4. **Segment Detection and Two Segment Rule:**
+4. **Segment Detection and Single-Segment Restriction:**
 
    - **Thoroughly** detect any demographic segments mentioned in the query. Populate the `"segments"` array accordingly (`[]` if none).
    - **Allowed Segment Categories:** Only detect segments belonging to the following categories: `country`, `age`, `generation`, `gender`, `org_size`, `employment_status`, `sector`, `job_level`, `marital_status`, `education`. Do not detect other types of segments.

--- a/public/prompts/1_data_retrieval.md
+++ b/public/prompts/1_data_retrieval.md
@@ -78,7 +78,7 @@ After analyzing the query, you must review the entire file to:
    - Apply case-insensitive matching and core concept extraction to map query keywords to canonical topics or their alternate phrasings.
    - Do not invent any topics—use only those in the mapping.
 
-4. **Segment Detection and Two Segment Rule:**
+4. **Segment Detection and Single-Segment Restriction:**
 
    - **Thoroughly** detect any demographic segments mentioned in the query. Populate the `"segments"` array accordingly (`[]` if none).
    - **Allowed Segment Categories:** Only detect segments belonging to the following categories: `country`, `age`, `generation`, `gender`, `org_size`, `employment_status`, `sector`, `job_level`, `marital_status`, `education`. Do not detect other types of segments.

--- a/utils/openai/1_data_retrieval.md
+++ b/utils/openai/1_data_retrieval.md
@@ -97,7 +97,7 @@ After analyzing the query, you must review the entire file to:
    - Apply case-insensitive matching and core concept extraction to map query keywords to canonical topics or their alternate phrasings.
    - Do not invent any topics—use only those in the mapping.
 
-4. **Segment Detection and Two Segment Rule:**
+4. **Segment Detection and Single-Segment Restriction:**
 
    - **Thoroughly** detect any demographic segments mentioned in the query (for `isFollowUp = false` primarily, as follow-ups use the stricter logic above).
    - **Allowed Segment Categories:** Only detect segments belonging to the following categories: `country`, `age`, `generation`, `gender`, `org_size`, `employment_status`, `sector`, `job_level`, `marital_status`, `education`. Do not detect other types of segments.


### PR DESCRIPTION
## Summary
- remove references to "Two-Segment Rule" and clarify that the dataset does not support any segment combinations
- rename headings to "Single-Segment Restriction"
- update prompts to reflect the new rule
- refresh documentation timestamps

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b0d0fa5d083259ac1c4fade7ea7eb