### PR TITLE
Remove deprecated flag usage

### DIFF
--- a/app/api/controllers/retrieveDataController.ts
+++ b/app/api/controllers/retrieveDataController.ts
@@ -11,7 +11,6 @@ import fs from "fs/promises";
 import path from "path";
 import logger from "../../../utils/shared/logger";
 import { unifiedOpenAIService } from "../services/unifiedOpenAIService";
-import { isFeatureEnabled } from "../../../utils/shared/feature-flags";
 import { getTopicForFileId } from "../../../utils/data/topicMapping";
 
 export async function postHandler(request) {
@@ -54,7 +53,7 @@ export async function postHandler(request) {
           topics.add(topic);
           
           // If data enrichment is requested, use unified OpenAI service
-          if (enrichData && isFeatureEnabled('USE_RESPONSES_API')) {
+          if (enrichData) {
             await enrichFileDataWithAI(jsonData, topic, file_id);
           }
 
@@ -84,7 +83,7 @@ export async function postHandler(request) {
         total_data_points: totalDataPoints,
         processing_time_ms: processingTime,
         retrieved_at: new Date().toISOString(),
-        used_unified_service: isFeatureEnabled('USE_RESPONSES_API')
+        used_unified_service: enrichData
       },
     };
     


### PR DESCRIPTION
## Summary
- clean up retrieve-data controller to stop referencing removed `USE_RESPONSES_API` feature flag

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c3b231be08325aa7ce56066a5a922