### PR TITLE
Fix import paths in EmbedClient

### DIFF
--- a/app/embed/EmbedClient.tsx
+++ b/app/embed/EmbedClient.tsx
@@ -6,11 +6,11 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { AssistantStream } from "openai/lib/AssistantStream";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import PromptInput from "../../../components/PromptInput";
-import { parseResponse } from "../../../utils/shared/helpers";
-import chatConfig from "../../../config/chat.config.json";
-import CollapsibleContent from "../../../components/CollapsibleContent";
-import { sendHeightToParent } from "../../../utils/shared/iframe/iframe-resizer";
+import PromptInput from "../../components/PromptInput";
+import { parseResponse } from "../../utils/shared/helpers";
+import chatConfig from "../../config/chat.config.json";
+import CollapsibleContent from "../../components/CollapsibleContent";
+import { sendHeightToParent } from "../../utils/shared/iframe/iframe-resizer";
 
 // Error boundary for markdown rendering during streaming
 class MarkdownErrorBoundary extends React.Component<


### PR DESCRIPTION
## Summary
- adjust component imports in `EmbedClient` so they resolve correctly

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c3d4c516083258b1173adcb605036