### PR TITLE
Fix feature flag name mismatch

### DIFF
--- a/utils/shared/feature-flags.ts
+++ b/utils/shared/feature-flags.ts
@@ -24,6 +24,7 @@ export interface FeatureFlagConfig {
 export interface FeatureFlags {
   ENHANCED_ERROR_HANDLING: FeatureFlagConfig;
   MONITOR_MIGRATION: FeatureFlagConfig;
+  FALLBACK_TO_LEGACY: FeatureFlagConfig;
 }
 
 /**
@@ -39,6 +40,11 @@ export const featureFlags: FeatureFlags = {
     enabled: true,
     envKey: 'MONITOR_MIGRATION',
     description: 'Controls whether to monitor migration progress and performance',
+  },
+  FALLBACK_TO_LEGACY: {
+    enabled: false,
+    envKey: 'FALLBACK_TO_LEGACY',
+    description: 'Allows rolling back to legacy implementation during migration',
   },
 };
 


### PR DESCRIPTION
## Summary
- extend feature-flag definitions to include `FALLBACK_TO_LEGACY`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c3f901c3483258d6ef879cce54f66