### PR TITLE
Wrap PromptInput in Suspense

### DIFF
--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1299,13 +1299,15 @@ function Embed(props) {
 
             {/* Input Container - STICKY BOTTOM */}
             <div className="bg-white py-3 sticky bottom-0 z-10 border-t border-gray-200 mt-auto">
-              <PromptInput
-                prompt={prompt}
-                setPrompt={setPrompt}
-                sendPrompt={sendPrompt}
-                threadId={threadId}
-                loading={loading}
-              />
+              <Suspense fallback={null}>
+                <PromptInput
+                  prompt={prompt}
+                  setPrompt={setPrompt}
+                  sendPrompt={sendPrompt}
+                  threadId={threadId}
+                  loading={loading}
+                />
+              </Suspense>
 
               {/* Legal Text - centered */}
               <div className="text-xs text-gray-500 text-center mt-2">


### PR DESCRIPTION
## Summary
- wrap PromptInput in a `<Suspense>` boundary so `useSearchParams` works in build

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test:unit` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c418d221c8325aa167a917b3c1498