### PR TITLE
Fix missing precompiled starter question files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,11 @@ const nextConfig = {
   distDir: ".next",
   experimental: {
     outputFileTracingIncludes: {
-      "/**": ["utils/openai/*.md", "scripts/output/split_data/*.json"],
+      "/**": [
+        "utils/openai/*.md",
+        "utils/openai/precompiled_starters/*.json",
+        "scripts/output/split_data/*.json",
+      ],
     },
   },
 };


### PR DESCRIPTION
## Summary
- include `utils/openai/precompiled_starters/*.json` in the Next.js file tracing config

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test:unit` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c50d683648325af2167e769b8249b